### PR TITLE
Using context::loadComponent instead of serviceComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,8 @@
   "readme": "README.md",
   "dependencies": {
     "@opuscapita/i18n": "^1.1.0",
-    "@opuscapita/react-loaders": "^0.1.9",
     "@opuscapita/react-reference-select": "^2.0.6",
-    "@opuscapita/service-base-ui": "^1.0.89",
+    "@opuscapita/service-base-ui": "^1.0.92",
     "bluebird": "^3.5.1",
     "cross-env": "^4.0.0",
     "jquery": "^3.2.1",

--- a/src/client/containers/Admin/AclEditor/AclEditor.js
+++ b/src/client/containers/Admin/AclEditor/AclEditor.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
 import translations from '../../i18n/index'
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 import './AclEditor.css';
 
 export default class AclEditor extends Components.ContextComponent {
@@ -11,15 +10,13 @@ export default class AclEditor extends Components.ContextComponent {
 
         context.i18n.register('AclEditor', translations);
 
-        this.AclEditor = serviceComponent({
-            serviceRegistry: () => ({ url: `/acl` }),
+        this.AclEditor = context.loadComponent({
             serviceName: 'acl' ,
             moduleName: 'acl-editor',
             jsFileName: 'editor-bundle'
         });
 
-        this.UserRolePicker = serviceComponent({
-            serviceRegistry: () => ({ url: `/user` }),
+        this.UserRolePicker = context.loadComponent({
             serviceName: 'user' ,
             moduleName: 'user-rolepicker',
             jsFileName: 'rolepicker-bundle'

--- a/src/client/containers/Admin/CustomerCreate.js
+++ b/src/client/containers/Admin/CustomerCreate.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 
 export default class CustomerCreate extends Components.ContextComponent {
   constructor(props, context) {
     super(props);
 
-    this.CustomerCreate = serviceComponent({
-      serviceRegistry: () => ({ url: `/customer` }),
+    this.CustomerCreate = context.loadComponent({
       serviceName: 'customer',
       moduleName: 'customer-creation',
       jsFileName: 'creation-bundle'

--- a/src/client/containers/Admin/CustomerEditor.js
+++ b/src/client/containers/Admin/CustomerEditor.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 import translations from '../i18n';
 
 export default class CustomerEditor extends Components.ContextComponent {
@@ -9,9 +8,7 @@ export default class CustomerEditor extends Components.ContextComponent {
     super(props);
     context.i18n.register('UserAdmin.Editor', translations);
 
-    const serviceRegistry = (service) => ({ url: `/customer` });
-    this.CustomerEditor = serviceComponent({
-      serviceRegistry,
+    this.CustomerEditor = context.loadComponent({
       serviceName: 'customer' ,
       moduleName: 'customer-information',
       jsFileName: 'information-bundle'

--- a/src/client/containers/Admin/CustomerList.js
+++ b/src/client/containers/Admin/CustomerList.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 export default class CustomerList extends Components.ContextComponent {
 
   constructor(props, context) {
     super(props);
 
-    const serviceRegistry = (service) => ({ url: `/customer` });
-    this.CustomerList = serviceComponent({
-      serviceRegistry,
+    this.CustomerList = context.loadComponent({
       serviceName: 'customer' ,
       moduleName: 'customer-list',
       jsFileName: 'list-bundle'

--- a/src/client/containers/Admin/RedisCommander.js
+++ b/src/client/containers/Admin/RedisCommander.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
 import translations from '../i18n'
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 export default class RedisCommander extends Components.ContextComponent {
 
@@ -10,10 +9,7 @@ export default class RedisCommander extends Components.ContextComponent {
 
         context.i18n.register('RedisCommander', translations);
 
-        const serviceRegistry = (service) => ({ url: `/redis-commander` });
-
-        this.RedisCommander = serviceComponent({
-            serviceRegistry,
+        this.RedisCommander = context.loadComponent({
             serviceName: 'redis-commander',
             moduleName: 'redis-commander-main',
             jsFileName: 'main-bundle'

--- a/src/client/containers/Admin/SupplierEditor.js
+++ b/src/client/containers/Admin/SupplierEditor.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 import translations from '../i18n';
 
 export default class SupplierEditor extends Components.ContextComponent {
@@ -9,9 +8,7 @@ export default class SupplierEditor extends Components.ContextComponent {
     super(props);
     context.i18n.register('UserAdmin.Editor', translations);
 
-    const serviceRegistry = (service) => ({ url: `/supplier` });
-    this.SupplierEditor = serviceComponent({
-      serviceRegistry,
+    this.SupplierEditor = context.loadComponent({
       serviceName: 'supplier' ,
       moduleName: 'supplier-information',
       jsFileName: 'information-bundle'

--- a/src/client/containers/Admin/SupplierList.js
+++ b/src/client/containers/Admin/SupplierList.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 export default class SupplierList extends Components.ContextComponent {
 
   constructor(props, context) {
     super(props);
 
-    const serviceRegistry = (service) => ({ url: `/supplier` });
-    this.SupplierList = serviceComponent({
-      serviceRegistry,
+    this.SupplierList = context.loadComponent({
       serviceName: 'supplier' ,
       moduleName: 'supplier-list',
       jsFileName: 'list-bundle'

--- a/src/client/containers/Admin/UserCreate.js
+++ b/src/client/containers/Admin/UserCreate.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 let getTenantType = function(params) {
   if (params.customerId) return 'customer';
@@ -14,8 +13,7 @@ export default class UserSelectCreate extends Components.ContextComponent {
     this.tenantType = getTenantType(props.params);
     this.tenantId = props.params.supplierId || props.params.customerId;
 
-    this.UserCreate = serviceComponent({
-      serviceRegistry: () => ({ url: `/user` }),
+    this.UserCreate = context.loadComponent({
       serviceName: 'user',
       moduleName: 'user-create',
       jsFileName: 'create-bundle'

--- a/src/client/containers/Admin/UserEditor.js
+++ b/src/client/containers/Admin/UserEditor.js
@@ -3,7 +3,6 @@ import { Components } from '@opuscapita/service-base-ui';
 import Tabs from 'react-bootstrap/lib/Tabs';
 import Tab from 'react-bootstrap/lib/Tab';
 import translations from '../i18n'
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 export default class UserEditor extends Components.ContextComponent {
 
@@ -12,18 +11,14 @@ export default class UserEditor extends Components.ContextComponent {
 
         context.i18n.register('UserAdmin.Editor', translations);
 
-        const serviceRegistry = (service) => ({ url: `/user` });
-
-        this.UserProfileEditor = serviceComponent({
-            serviceRegistry,
-            serviceName: 'user' ,
+        this.UserProfileEditor = context.loadComponent({
+            serviceName: 'user',
             moduleName: 'user-profile',
             jsFileName: 'profile-bundle'
         });
 
-        this.UserRoleEditor = serviceComponent({
-            serviceRegistry,
-            serviceName: 'user' ,
+        this.UserRoleEditor = context.loadComponent({
+            serviceName: 'user',
             moduleName: 'user-role',
             jsFileName: 'role-bundle'
         });

--- a/src/client/containers/Admin/UserList.js
+++ b/src/client/containers/Admin/UserList.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
 import translations from '../i18n'
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 export default class UserList extends Components.ContextComponent {
 
@@ -12,11 +11,8 @@ export default class UserList extends Components.ContextComponent {
 
         context.i18n.register('UserAdmin.List', translations);
 
-        const serviceRegistry = (service) => ({ url: `/user` });
-
-        this.UserList = serviceComponent({
-            serviceRegistry,
-            serviceName: 'user' ,
+        this.UserList = context.loadComponent({
+            serviceName: 'user',
             moduleName: 'user-list',
             jsFileName: 'list-bundle'
         });

--- a/src/client/containers/BuyerDashboard.js
+++ b/src/client/containers/BuyerDashboard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components, System } from '@opuscapita/service-base-ui';
 import translations from './i18n';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 export default class BuyerDashboard extends Components.ContextComponent
 {
@@ -11,16 +10,12 @@ export default class BuyerDashboard extends Components.ContextComponent
 
         context.i18n.register('BuyerDashboard', translations);
 
-        const serviceRegistry = (service) => ({ url: '/onboarding' });
-
-        this.FunnelChart = serviceComponent({
-            serviceRegistry,
+        this.FunnelChart = context.loadComponent({
             serviceName: 'onboarding',
             moduleName: 'funnelChart'
         });
 
-        this.RecentCampaigns = serviceComponent({
-            serviceRegistry,
+        this.RecentCampaigns = context.loadComponent({
             serviceName: 'onboarding',
             moduleName: 'recentCampaigns'
         });

--- a/src/client/containers/BuyerInformation.js
+++ b/src/client/containers/BuyerInformation.js
@@ -4,7 +4,6 @@ import { Components } from '@opuscapita/service-base-ui';
 import translations from './i18n';
 import Tabs from 'react-bootstrap/lib/Tabs';
 import Tab from 'react-bootstrap/lib/Tab';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 class BuyerInformation extends Components.ContextComponent
 {
@@ -15,38 +14,31 @@ class BuyerInformation extends Components.ContextComponent
 
     context.i18n.register('BuyerInformation', translations);
 
-    const serviceRegistry = (service) => ({ url: '/customer' });
-
-    this.CustomerEditor = serviceComponent({
-      serviceRegistry,
+    this.CustomerEditor = context.loadComponent({
       serviceName: 'customer' ,
       moduleName: 'customer-information',
       jsFileName: 'information-bundle'
     });
 
-    this.CustomerOrganization = serviceComponent({
-      serviceRegistry,
+    this.CustomerOrganization = context.loadComponent({
       serviceName: 'customer' ,
       moduleName: 'customer-organization',
       jsFileName: 'organization-bundle'
     });
 
-    this.CustomerAddressEditor = serviceComponent({
-      serviceRegistry,
+    this.CustomerAddressEditor = context.loadComponent({
       serviceName: 'customer' ,
       moduleName: 'customer-addresses',
       jsFileName: 'addresses-bundle'
     });
 
-    this.CustomerContactEditor = serviceComponent({
-      serviceRegistry,
+    this.CustomerContactEditor = context.loadComponent({
       serviceName: 'customer' ,
       moduleName: 'customer-contacts',
       jsFileName: 'contacts-bundle'
     });
 
-    this.CustomerBankAccountEditor = serviceComponent({
-      serviceRegistry,
+    this.CustomerBankAccountEditor = context.loadComponent({
       serviceName: 'customer' ,
       moduleName: 'customer-bank_accounts',
       jsFileName: 'bank_accounts-bundle'

--- a/src/client/containers/SellerDashboard.js
+++ b/src/client/containers/SellerDashboard.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Components } from '@opuscapita/service-base-ui';
 import translations from './i18n';
 import request from 'superagent-bluebird-promise';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 class SellerDashboard extends Components.ContextComponent
 {
@@ -23,8 +22,7 @@ class SellerDashboard extends Components.ContextComponent
 
         const serviceRegistry = (service) => ({ url : '/supplier' });
 
-        this.SupplierProfileStrength = serviceComponent({
-            serviceRegistry,
+        this.SupplierProfileStrength = context.loadComponent({
             serviceName: 'supplier',
             moduleName: 'supplier-profile_strength',
             jsFileName: 'profile_strength-bundle'
@@ -97,7 +95,7 @@ class SellerDashboard extends Components.ContextComponent
     render()
     {
         const { i18n, userData } = this.context;
-        
+
         this.context.setPageTitle(i18n.getMessage('SellerDashboard.page.title'));
 
         return(

--- a/src/client/containers/SupplierDirectory.js
+++ b/src/client/containers/SupplierDirectory.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components } from '@opuscapita/service-base-ui';
 import translations from './i18n'
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 export default class SupplierDirectory extends Components.ContextComponent {
 
@@ -11,10 +10,7 @@ export default class SupplierDirectory extends Components.ContextComponent {
 
       context.i18n.register('SupplierDirectory', translations);
 
-      const serviceRegistry = (service) => ({ url: `/supplier` });
-
-      this.Directory = serviceComponent({
-        serviceRegistry,
+      this.Directory = context.loadComponent({
         serviceName: 'supplier' ,
         moduleName: 'supplier-directory',
         jsFileName: 'directory-bundle'

--- a/src/client/containers/SupplierInformation.js
+++ b/src/client/containers/SupplierInformation.js
@@ -4,7 +4,6 @@ import { Components } from '@opuscapita/service-base-ui';
 import translations from './i18n';
 import Tabs from 'react-bootstrap/lib/Tabs';
 import Tab from 'react-bootstrap/lib/Tab';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 class SupplierInformation extends Components.ContextComponent
 {
@@ -15,39 +14,32 @@ class SupplierInformation extends Components.ContextComponent
 
       context.i18n.register('SupplierInformation', translations);
 
-      const serviceRegistry = (service) => ({ url: '/supplier' });
-
-      this.SupplierEditor = serviceComponent({
-        serviceRegistry,
+      this.SupplierEditor = context.loadComponent({
         serviceName: 'supplier' ,
         moduleName: 'supplier-information',
         jsFileName: 'information-bundle'
       });
 
-      this.SupplierAddressEditor = serviceComponent({
-        serviceRegistry,
+      this.SupplierAddressEditor = context.loadComponent({
         serviceName: 'supplier' ,
         moduleName: 'supplier-address',
         jsFileName: 'address-bundle'
       });
 
-      this.SupplierContactEditor = serviceComponent({
-        serviceRegistry,
+      this.SupplierContactEditor = context.loadComponent({
         serviceName: 'supplier' ,
         moduleName: 'supplier-contact',
         jsFileName: 'contact-bundle'
       });
 
-      this.SupplierBankAccountEditor = serviceComponent({
-        serviceRegistry,
+      this.SupplierBankAccountEditor = context.loadComponent({
         serviceName: 'supplier' ,
         moduleName: 'supplier-bank_accounts',
         jsFileName: 'bank_accounts-bundle'
       });
 
       if (context.userData.roles.includes('supplier-admin')) {
-        this.SupplierApproval = serviceComponent({
-          serviceRegistry,
+        this.SupplierApproval = context.loadComponent({
           serviceName: 'supplier',
           moduleName: 'supplier-access_approval',
           jsFileName: 'access_approval-bundle'

--- a/src/client/containers/SupplierRegistrationForm.js
+++ b/src/client/containers/SupplierRegistrationForm.js
@@ -5,7 +5,6 @@ import translations from './i18n';
 import Tabs from 'react-bootstrap/lib/Tabs';
 import Tab from 'react-bootstrap/lib/Tab';
 import { OnboardingUserService } from '../api';
-import serviceComponent from '@opuscapita/react-loaders/lib/serviceComponent';
 
 class SupplierRegistrationForm extends Components.ContextComponent {
 
@@ -19,11 +18,8 @@ class SupplierRegistrationForm extends Components.ContextComponent {
 
       context.i18n.register('SupplierRegistrationForm', translations);
 
-      const serviceRegistry = (service) => ({ url: '/supplier' });
-
-      this.SupplierRegistrationEditor = serviceComponent({
-        serviceRegistry,
-        serviceName: 'supplier' ,
+      this.SupplierRegistrationEditor = context.loadComponent({
+        serviceName: 'supplier',
         moduleName: 'supplier-registration',
         jsFileName: 'registration-bundle'
       });


### PR DESCRIPTION
Key difference is that context::loadComponent() will keep spinner visible until all components are loaded.